### PR TITLE
Fixes for reliability and compilation cancellation

### DIFF
--- a/src/document.ts
+++ b/src/document.ts
@@ -30,6 +30,11 @@ export class AsmDocument {
         this.update(false);
     }
 
+    updateCompilationInfo(compinfo: CompilationInfo) {
+        this._compinfo = compinfo;
+        this.update(false);
+    }
+
     private updateLater(deleted: boolean = false) {
         // Workarond for https://github.com/Microsoft/vscode/issues/72831
         setTimeout(async () => await this.update(deleted), 100);

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -44,8 +44,8 @@ export class AsmProvider implements TextDocumentContentProvider {
         doc?.updateCompilationInfo(compinfo);
     }
 
-    unload(srcUri: Uri) {
-        const asmUri = getAsmUri(srcUri);
+    unload(srcOrAsmUri: Uri) {
+        const asmUri = getAsmUri(srcOrAsmUri);
         const doc = this._documents.get(asmUri.path);
         doc?.dispose();
         this._documents.delete(asmUri.path);
@@ -59,6 +59,7 @@ export class AsmProvider implements TextDocumentContentProvider {
     }
 
     dispose(): void {
+        this._documents.forEach(doc => doc.dispose());
         this._documents.clear();
         this._onDidChange.dispose();
     }

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -37,7 +37,11 @@ export class AsmProvider implements TextDocumentContentProvider {
 
     async loadCompilationInfo(srcUri: Uri, asmUri: Uri, customCommand: string[]) {
         const compdb = await CompilationDatabase.for(srcUri);
-        this._compinfo.set(asmUri.path, { srcUri, compdb, customCommand: customCommand });
+        const compinfo = { srcUri, compdb, customCommand };
+        this._compinfo.set(asmUri.path, compinfo);
+
+        const doc = this._documents.get(asmUri.path);
+        doc?.updateCompilationInfo(compinfo);
     }
 
     unload(srcUri: Uri) {


### PR DESCRIPTION
This addresses a few issues:

- Updates to the compilation db or custom command would not result in recompile
- Updating the source file wouldn't reliably result in a re-compile nor kill pending compilation
- Manually cancelling would not kill the processes, which could get stuck
- Reloading the extension would not dispose all subscription or kill processes
- Decorations would go away when switching tabs (fixes #9)

P.S. Sorry for the large changeset, but it should be easier to review ignoring whitespace. 😀