### PR TITLE
Add integration with cmake-tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
         "ts-loader": "^9.3.1",
         "typescript": "^4.7.4",
         "webpack": "^5.76.0",
-        "webpack-cli": "^4.10.0"
+        "webpack-cli": "^4.10.0",
+        "vscode-cmake-tools": "^1.0.0"
     }
 }


### PR DESCRIPTION
Get compile commands from Microsoft cmake-tools extension, when `compile_commands.json` is missing.

With this PR, extension users what uses CMake no need to export `compile_commands.json` and specify path for extension