### PR TITLE
Add setting to specify flags for assembly listing

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,20 @@
                         "default": true,
                         "description": "Dim the lines that was thrown away by compiler",
                         "scope": "resource"
+                    },
+                    "compilerexplorer.compilerArguments": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "default": [
+                            "-g",
+                            "-S",
+                            "-o",
+                            "-"
+                        ],
+                        "description": "Compiler arguments to get assembly listing",
+                        "scope": "resource"
                     }
                 }
             }

--- a/src/compdb.ts
+++ b/src/compdb.ts
@@ -131,7 +131,8 @@ export class CompilationDatabase implements Disposable {
         const compileArguments = customCommand.length != 0 ? customCommand : ccommand.arguments;
         const cxxfiltExe = await this.getCxxFiltExe(compileArguments[0]);
         const command = compileArguments[0];
-        const args = [...compileArguments.slice(1), ccommand.file, '-g', '-S', '-o', '-'];
+        const asmArgs = workspace.getConfiguration('compilerexplorer').get<string[]>('compilerArguments', ['-g', '-S', '-o', '-']);
+        const args = [...compileArguments.slice(1), ccommand.file, ...asmArgs];
 
         getOutputChannel().appendLine(`Compiling using: ${command} ${args.join(' ')}`);
 


### PR DESCRIPTION
E.g. This helps to select default assembler style by adding option `-masm=intel`