### PR TITLE
Correctly handle invalid file paths

### DIFF
--- a/src/compdb.ts
+++ b/src/compdb.ts
@@ -111,7 +111,11 @@ export class CompilationDatabase implements Disposable {
         for (let command of commands) {
             let filePath = command.file;
             if(!Path.isAbsolute(filePath)) {
-                filePath = await fs.realpath(Path.join(command.directory, command.file));
+                try {
+                    filePath = await fs.realpath(Path.join(command.directory, command.file));
+                } catch(err) {
+                    getOutputChannel().appendLine(`Cannot resolve relative file path: ${err}`);
+                }
             }
             ccommands.set(filePath, command);
         }

--- a/src/compdb.ts
+++ b/src/compdb.ts
@@ -139,7 +139,7 @@ export class CompilationDatabase implements Disposable {
 
         getOutputChannel().appendLine(`Compiling using: ${command} ${args.join(' ')}`);
 
-        let commandOptions: SpawnOptionsWithStdioTuple<StdioNull, StdioPipe, StdioPipe> = { stdio: ['ignore', 'pipe', 'pipe'], shell: true }
+        let commandOptions: SpawnOptionsWithStdioTuple<StdioNull, StdioPipe, StdioPipe> = { stdio: ['ignore', 'pipe', 'pipe'] }
         if (existsSync(ccommand.directory)) {
             commandOptions.cwd = ccommand.directory;
         }


### PR DESCRIPTION
Hello @harikrishnan94 :wink:

**This PR fixes the following issues:**
* If the compilation database contains relative file paths that cannot be resolved, the whole compilation database is going to be ignored because of an exception.
* Running the command in a shell environment is going to fail when the command contains unescaped special shell characters such as `<` (specifying a system include) which gets misinterpreted