### PR TITLE
Add intel syntax option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,11 @@ Run `compilerexplorer.disassOutputWithCustomCommand` from Command palette to use
 ## Requirements
 
 `compilerexplorer.compilationDirectory` must point to location of build directory containing compile commands.
+
+## Settings
+
+`compilerexplorer.compilationDirectory`: See Requirements.
+
+`compilerexplorer.dimUnusedSourceLines`: Dim the lines that was thrown away by compiler.
+
+`compilerexplorer.intelSyntax`: Whether to use Intel syntax for the disassembly.

--- a/package.json
+++ b/package.json
@@ -51,6 +51,12 @@
                         "default": true,
                         "description": "Dim the lines that was thrown away by compiler",
                         "scope": "resource"
+                    },
+                    "compilerexplorer.intelSyntax": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Whether to append the '-masm=intel' flag when generating the assembly",
+                        "scope": "resource"
                     }
                 }
             }

--- a/src/compdb.ts
+++ b/src/compdb.ts
@@ -168,6 +168,11 @@ export class CompilationDatabase implements Disposable {
         const command = compileArguments[0];
         const args = [...compileArguments.slice(1), ccommand.file, '-g', '-S', '-o', '-'];
 
+        const intelSyntax = workspace.getConfiguration('compilerexplorer').get<boolean>('intelSyntax', false);
+        if (intelSyntax) {
+            args.push('-masm=intel');
+        }
+
         getOutputChannel().appendLine(`Compiling using: ${command} ${args.join(' ')}`);
 
         let commandOptions: SpawnOptionsWithStdioTuple<StdioNull, StdioPipe, StdioPipe> = { stdio: ['ignore', 'pipe', 'pipe'] }


### PR DESCRIPTION
This adds an option to add the intel syntax argument, disabled by default.

cc @harikrishnan94 