### PR TITLE
Fix #34 (windows)

### DIFF
--- a/src/compdb.ts
+++ b/src/compdb.ts
@@ -67,7 +67,7 @@ export class CompilationDatabase implements Disposable {
     static async for(srcUri: Uri): Promise<CompilationDatabase> {
         const buildDirectory = resolvePath(workspace.getConfiguration('compilerexplorer')
             .get<string>('compilationDirectory', '${workspaceFolder}'), srcUri);
-        const compileCommandsFile = Uri.joinPath(Uri.parse(buildDirectory), 'compile_commands.json');
+        const compileCommandsFile = Uri.joinPath(buildDirectory, 'compile_commands.json');
 
         let compdb = CompilationDatabase.compdbs.get(compileCommandsFile);
         if (compdb) return compdb;
@@ -75,7 +75,7 @@ export class CompilationDatabase implements Disposable {
         try {
             const commands = await CompilationDatabase.load(compileCommandsFile);
             if (commands.size == 0) throw new Error('compile_commands.json is empty');
-    
+
             compdb = new CompilationDatabase(compileCommandsFile, commands);
             this.compdbs.set(compileCommandsFile, compdb);
         } catch (e) {
@@ -148,7 +148,9 @@ export class CompilationDatabase implements Disposable {
                     getOutputChannel().appendLine(`Cannot resolve relative file path: ${err}`);
                 }
             }
-            ccommands.set(filePath, command);
+            // On Windows, compile_commands file path are incompatible with what vscode provides, so normalize it with a Uri
+            let normalized = Uri.file(filePath);
+            ccommands.set(normalized.fsPath, command);
         }
 
         return ccommands;
@@ -166,7 +168,7 @@ export class CompilationDatabase implements Disposable {
         const compileArguments = customCommand.length != 0 ? customCommand : ccommand.arguments;
         const cxxfiltExe = await this.getCxxFiltExe(compileArguments[0]);
         const command = compileArguments[0];
-        const args = [...compileArguments.slice(1), ccommand.file, '-g', '-S', '-o', '-'];
+        const args = [...compileArguments.slice(1), '-g', '-S', '-o', '-'];
 
         getOutputChannel().appendLine(`Compiling using: ${command} ${args.join(' ')}`);
 
@@ -420,12 +422,9 @@ export function constructCompileCommand(command: string, args: string[]): string
 
 export function getAsmUri(srcUri: Uri): Uri {
     // by default just replace file extension with '.S'
-    const asmUri = srcUri.with({
-        scheme: AsmProvider.scheme,
-        path: pathWithoutExtension(srcUri.path) + ".S",
-    });
-
-    return asmUri;
+    const newPath = pathWithoutExtension(srcUri.fsPath) + ".S";
+    // Make a new Uri to normalize the path
+    return Uri.file(newPath).with({ scheme: AsmProvider.scheme });
 }
 
 /**
@@ -437,7 +436,7 @@ function pathWithoutExtension(path: string): string {
 
 // Resolve path with almost all variable substitution that supported in
 // Debugging and Task configuration files
-function resolvePath(path: string, srcUri: Uri): string {
+function resolvePath(path: string, srcUri: Uri): Uri {
     const workspacePath = workspace.getWorkspaceFolder(srcUri)?.uri.fsPath!;
 
     const variables: Record<string, string> = {
@@ -471,7 +470,8 @@ function resolvePath(path: string, srcUri: Uri): string {
     );
 
     // normalize a path, reducing '..' and '.' parts
-    return Path.normalize(resolvedPath);
+    // Wrap in a Uri so that the path is correctly normalized on Windows
+    return Uri.file(Path.normalize(resolvedPath));
 }
 
 let outputChannel: OutputChannel | undefined = undefined;


### PR DESCRIPTION
This is an attempt to fix all the issues I had when using with mingw and cmake on Windows.

The core issue is in the path handling:
- compile_commands.json stores the path as `C:/my/path`
- vscode uri are either `c:\\my\\path` or `C:\\my\\path`

So the general fix is to manipulate Uri.fsPath as much as possible, as it normalizes the path to a common format.

First issue is that the compile_commands could not be found, so I adjusted how the compileCommandsFile variable is generated.
Second issue was that the keys in the CompilationDatabase are compile_command encoded, but indexing used vscode Uri encode. So each key goes through a `Uri.file().fsPath` for normalization.

Third issue was that the disassembly command line looked like this: 
```
Compiling using: c:\Dev\mingw64-16.1\bin\g++.exe -DLIBCEDIMU_ENABLE_LOG -DLIBCEDIMU_ENABLE_RENDERERSIMD @CMakeFiles/CeDImu.dir/includes_CXX.rsp -O2 -DNDEBUG -std=gnu++26 -Wall -Wextra -pedantic -march=native -Wa,-muse-unaligned-vector-move -Wnrvo C:\Users\Stovent\Dropbox\Dev\CeDImu\src\CDI\cores\SCC68070\Interpreter.cpp C:/Users/Stovent/Dropbox/Dev/CeDImu/src/CDI/cores/SCC68070/Interpreter.cpp -g -S -o - -masm=intel
g++.exe: fatal error: cannot specify '-o' with '-c', '-S' or '-E' with multiple files
```
The filepath appears twice, so I removed the second appearance.

cc @harikrishnan94 and @Raildex if you have the time to try it.