### PR TITLE
Release 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## v0.8.0
+
+### Features
+* Pick up compile commands from the Microsoft CMake Tools extension when compile_commands.json is missing, so CMake users no longer need to export it by hand, by @sr-tream in #51
+* Add a compilerexplorer.intelSyntax setting to emit Intel syntax assembly, off by default, by @Stovent in #61
+
+### Fixes
+* Fix path handling on Windows, covering drive letter case and separator mismatches between compile_commands.json and VS Code URIs (#34), by @Stovent in #62
+* Correctly handle invalid file paths, so one unresolvable relative path no longer causes the whole compilation database to be ignored, by @dprogm in #53
+
+Thanks to @sr-tream, @Stovent and @dprogm for the contributions in this release.
+
 ## v0.7.1
 * Make use of the 'directory' property as specified in the JSON compilation database format specification by @dprogm in #36
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "Show Disassembly output to source relations",
     "publisher": "harikrishnan94",
     "icon": "icons/asm.png",
-    "version": "0.7.4",
+    "version": "0.8.0",
     "author": {
         "email": "harikrishnan.prabakaran@gmail.com",
         "name": "Harikrishnan Prabakaran"


### PR DESCRIPTION
0.8.0: version bump + changelog. No code changes.

Since 0.7.4:
1) Compile commands now come from the CMake Tools extension when compile_commands.json is missing, by @sr-tream in #51
2) New compilerexplorer.intelSyntax setting, emits Intel syntax assembly, off by default, by @Stovent in #61
3) Windows path handling fixed for drive letter case and separator mismatches (#34), by @Stovent in #62
4) One unresolvable relative path no longer makes the whole compilation database get ignored, by @dprogm in #53

Thanks @sr-tream, @Stovent, @dprogm.

Tag v0.8.0 and marketplace publish follow once this lands.